### PR TITLE
Fix transform error

### DIFF
--- a/eg3d/run_projector.py
+++ b/eg3d/run_projector.py
@@ -118,9 +118,9 @@ def run(
     c = torch.FloatTensor(c).cuda()
 
     trans = transforms.Compose([
+        transforms.Resize((512,512)),
         transforms.ToTensor(),
         transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
-        transforms.Resize((512,512))
     ])
     from_im = trans(image).cuda()
     id_image = torch.squeeze((from_im.cuda() + 1) / 2) * 255


### PR DESCRIPTION
Getting error `TypeError: img should be PIL Image. Got <class 'torch.Tensor'>` when `Resize` on `torch.Tensor` instead of `PIL.Images`